### PR TITLE
Allow fuse-overlayfs with all file types, only warn when unexpectedly readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--fakeroot` that probably requires a sandbox image that was built with
   `--fix-perms`.
 - The `--nvccli` option implies `--nv`.
+- Replaced checks for compatible filesystem types when using fuse-overlayfs
+  with an INFO message when an incompatible filesystem type causes it to
+  be unwritable by a fakeroot user.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -628,6 +628,9 @@ func (c *container) mountGeneric(mnt *mount.Point, tag mount.AuthorizedTag) (err
 		dest = filepath.Join(c.session.FinalPath(), dest)
 	} else {
 		dest = mnt.Destination
+		if mnt.Type == "overlay" && c.session.GetReadonly() {
+			flags |= syscall.MS_RDONLY
+		}
 	}
 
 	if remount || propagation {
@@ -947,6 +950,7 @@ func (c *container) addOverlayMount(system *mount.System) error {
 	nb := 0
 	ov := c.session.Layer.(*overlay.Overlay)
 	hasUpper := false
+	hasWritable := false
 
 	if c.engine.EngineConfig.GetWritableTmpfs() {
 		sylog.Debugf("Setup writable tmpfs overlay")
@@ -981,6 +985,7 @@ func (c *container) addOverlayMount(system *mount.System) error {
 		}
 
 		hasUpper = true
+		hasWritable = true
 	}
 
 	for _, img := range c.engine.EngineConfig.GetImageList() {
@@ -1002,6 +1007,9 @@ func (c *container) addOverlayMount(system *mount.System) error {
 			src := img.Source
 			offset := overlay.Offset
 			size := overlay.Size
+			if img.Writable {
+				hasWritable = true
+			}
 
 			switch overlay.Type {
 			case image.EXT3:
@@ -1043,30 +1051,33 @@ func (c *container) addOverlayMount(system *mount.System) error {
 				}
 				system.Points.AddRemount(mount.PreLayerTag, dst, flags)
 
-				if !img.Writable {
-					// check if the sandbox directory is located on a compatible
-					// filesystem usable overlay lower directory
-					if err := fsoverlay.CheckLower(img.Path, 0); err != nil {
-						return err
+				if !overlayImageDriver {
+					// When no overlay image driver available,
+					//  make sure filesystems type are compatible
+					//  with kernel overlayfs
+					if !img.Writable {
+						// check if the sandbox directory is located on a compatible
+						// filesystem usable overlay lower directory
+						if err := fsoverlay.CheckLower(img.Path); err != nil {
+							return err
+						}
+					} else {
+						// check if the sandbox directory is located on a compatible
+						// filesystem usable with overlay upper directory
+						if err := fsoverlay.CheckUpper(img.Path); err != nil {
+							return err
+						}
 					}
+				}
+
+				if !img.Writable {
 					if fs.IsDir(filepath.Join(img.Path, "upper")) {
 						ov.AddLowerDir(filepath.Join(dst, "upper"))
 					} else {
 						ov.AddLowerDir(dst)
 					}
-				} else {
-					// check if the sandbox directory is located on a compatible
-					// filesystem usable with overlay upper directory
-					allowType := int64(0)
-					if overlayImageDriver {
-						// The imageDriver is likely to able to handle
-						//  a fuse upper even though the kernel can't
-						allowType = fsoverlay.Fuse
-					}
-					if err := fsoverlay.CheckUpper(img.Path, allowType); err != nil {
-						return err
-					}
 				}
+
 			default:
 				return fmt.Errorf("%s: overlay image with unknown format", img.Path)
 			}
@@ -1090,6 +1101,10 @@ func (c *container) addOverlayMount(system *mount.System) error {
 				hasUpper = true
 			}
 		}
+	}
+
+	if !hasWritable {
+		c.session.SetReadonly()
 	}
 
 	if hasUpper {

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -26,7 +26,8 @@ const (
 // Session directory layout manager
 type Session struct {
 	*Manager
-	Layer layer
+	Layer    layer
+	readonly bool
 }
 
 // Layer describes a layer interface added on top of session layout
@@ -98,6 +99,16 @@ func (s *Session) OverrideDir(path string, realpath string) {
 func (s *Session) RootFsPath() string {
 	path, _ := s.GetPath(rootFsDir)
 	return path
+}
+
+// SetReadonly sets the session to be Readonly
+func (s *Session) SetReadonly() {
+	s.readonly = true
+}
+
+// GetReadonly returns true if the session is Readonly
+func (s *Session) GetReadonly() bool {
+	return s.readonly
 }
 
 func (s *Session) createLayout(system *mount.System) error {

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -69,7 +69,7 @@ var incompatibleFs = map[int64]fs{
 	},
 }
 
-func check(path string, d dir, allowType int64) error {
+func check(path string, d dir) error {
 	stfs := &unix.Statfs_t{}
 
 	if err := statfs(path, stfs); err != nil {
@@ -78,10 +78,6 @@ func check(path string, d dir, allowType int64) error {
 
 	fs, ok := incompatibleFs[int64(stfs.Type)]
 	if !ok || (ok && fs.overlayDir&d == 0) {
-		return nil
-	}
-
-	if int64(stfs.Type) == allowType {
 		return nil
 	}
 
@@ -94,16 +90,14 @@ func check(path string, d dir, allowType int64) error {
 
 // CheckUpper checks if the underlying filesystem of the
 // provided path can be used as an upper overlay directory.
-// allowType is an optional filesystem type to always allow.
-func CheckUpper(path string, allowType int64) error {
-	return check(path, upperDir, allowType)
+func CheckUpper(path string) error {
+	return check(path, upperDir)
 }
 
 // CheckLower checks if the underlying filesystem of the
 // provided path can be used as lower overlay directory.
-// allowType is an optional filesystem type to always allow.
-func CheckLower(path string, allowType int64) error {
-	return check(path, lowerDir, allowType)
+func CheckLower(path string) error {
+	return check(path, lowerDir)
 }
 
 type errIncompatibleFs struct {

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -170,9 +170,9 @@ func TestCheckLowerUpper(t *testing.T) {
 
 		switch tt.dir {
 		case lowerDir:
-			err = CheckLower(tt.path, 0)
+			err = CheckLower(tt.path)
 		case upperDir:
-			err = CheckUpper(tt.path, 0)
+			err = CheckUpper(tt.path)
 		}
 
 		if err != nil && tt.expectedSuccess {


### PR DESCRIPTION
test PR